### PR TITLE
Add partials support

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,24 @@ catch (ex) {
 
 if (!dust) throw new Error('"dustjs-linkedin" or "dust" module not found')
 
+var getBaseDir = function(options) {
+  if (options && options.baseDir)
+    return options.baseDir
+  return ''
+}
+
+var getTemplateExt = function(options) {
+  if (options && options.defaultExt && options.defaultExt.length > 0)
+    return '.' + options.defaultExt
+  return '.dust'
+}
+
 module.exports = {
   module: {
     compile: function(template, options, callback) {
-      var fileExtension = options.defaultExtension || 'dust'
       dust.onLoad = function(name, callback) {
-          fs.readFile(Path.join(options.basedir, name + '.' + fileExtension), function(err, data) {
+        var templateFile = Path.join(getBaseDir(options), name + getTemplateExt(options))
+        fs.readFile(templateFile, function(err, data) {
           if (err)
             throw err
           callback(err, data.toString())

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 var dust
+var fs = require('fs')
+var Path = require('path')
 
 try {
   dust = require('dustjs-linkedin')
@@ -15,6 +17,14 @@ if (!dust) throw new Error('"dustjs-linkedin" or "dust" module not found')
 module.exports = {
   module: {
     compile: function(template, options, callback) {
+      var fileExtension = options.defaultExtension || 'dust'
+      dust.onLoad = function(name, callback) {
+          fs.readFile(Path.join(options.basedir, name + '.' + fileExtension), function(err, data) {
+          if (err)
+            throw err
+          callback(err, data.toString())
+        })
+      }
       var compiled = dust.compileFn(template, options && options.name)
       process.nextTick(function() {
         callback(null, function(context, options, callback) {

--- a/test/templates/_include.dust
+++ b/test/templates/_include.dust
@@ -1,0 +1,1 @@
+I am an include.

--- a/test/templates/_layout.dust
+++ b/test/templates/_layout.dust
@@ -1,0 +1,2 @@
+I am a layout.
+{+content}invalid content{/content}

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,8 @@ var assert = require('assert')
 
 var dust = require('../index')
 
+var options = {baseDir: "test/templates"}
+
 assert(dust.module, 'module does not exist')
 assert(dust.module.compile, 'compile does not exist')
 assert.equal(dust.compileMode, 'async', 'compileMode not properly set')
@@ -13,7 +15,27 @@ dust.module.compile('hello {x}!', null, function(err, fn) {
   fn({ x: 'world' }, null, function(err, str) {
     assert(!err, 'render resulted in error')
     assert.equal(str, 'hello world!', 'unexpected render result')
+  })
+})
 
-    console.log('Tests passed!')
+// partials
+dust.module.compile('hello {x}!{>_include /}', options, function(err, fn) {
+  assert(!err, 'compile resulted in error')
+  assert.equal(typeof fn, 'function', 'compile result not a function')
+
+  fn({ x: 'world' }, null, function(err, str) {
+    assert(!err, 'render resulted in error')
+    assert.equal(str, 'hello world!I am an include.', 'unexpected partial render result: ' + str)
+  })
+})
+
+// layouts
+dust.module.compile('{>_layout /}{<content}hello {x}!{/content}', options, function(err, fn) {
+  assert(!err, 'compile resulted in error')
+  assert.equal(typeof fn, 'function', 'compile result not a function')
+
+  fn({ x: 'world' }, null, function(err, str) {
+    assert(!err, 'render resulted in error')
+    assert.equal(str, 'I am a layout.hello world!', 'unexpected layout render result: ' + str)
   })
 })


### PR DESCRIPTION
Allows you to extend  and include other templates (`{>template /}`).
Currently requires that you pass in a compiler option for the base template directory `baseDir`.

It does the job I was after, but I am not thrilled about passing in the separate compileOptions.

Should probably see how it works with precompiled templates as well.
https://www.omniref.com/js/npm/dustjs-linkedin/0.4.0#label-Installation

I do not believe this is its final form, but it is a start.
